### PR TITLE
Re-Implemented Load Endpoint Plus Other Adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules
 coverage
 .DS_Store

--- a/use_cases/kg_chat/README.md
+++ b/use_cases/kg_chat/README.md
@@ -8,8 +8,9 @@ If you are not using a Sandbox instance, make sure you have APOC and GDS librari
 
 - Create `.env` file
 - Populate Neo4j and OpenAI credentials in the `.env` as shown in the `.env.example`
+  - If you do have an OpenAI API key, you can get one through an [OpenAI Platform Account](https://platform.openai.com/).
 - Start the project by running `docker-compose up`
-- Open your favorite internet browser at TBD
+- Open your favorite internet browser at [localhost:4173/use-cases/chat-with-kg/index.html](http://localhost:4173/use-cases/chat-with-kg/index.html)
 
 ## API
 

--- a/use_cases/kg_chat/docker-compose.yml
+++ b/use_cases/kg_chat/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   neo4j:
-    image: neo4j:5.7
+    image: neo4j:5.9
     restart: always
     hostname: kgchat-neo4j
     container_name: kgchat-neo4j

--- a/use_cases/shared/driver/neo4j.py
+++ b/use_cases/shared/driver/neo4j.py
@@ -4,7 +4,6 @@ from neo4j import GraphDatabase, exceptions
 
 from logger import logger
 
-
 node_properties_query = """
 CALL apoc.meta.data()
 YIELD label, other, elementType, type, property
@@ -78,9 +77,9 @@ class Neo4jDatabase:
         return [r.data() for r in result]
 
     def query(
-        self,
-        cypher_query: str,
-        params: Optional[Dict] = {}
+            self,
+            cypher_query: str,
+            params: Optional[Dict] = {}
     ) -> List[Dict[str, Any]]:
         with self._driver.session() as session:
             try:
@@ -100,7 +99,8 @@ class Neo4jDatabase:
             except exceptions.ClientError as e:
                 # Catch access mode errors
                 if e.code == "Neo.ClientError.Statement.AccessMode":
-                    return [{"code": "error", "message": "Couldn't execute the query due to the read only access to Neo4j"}]
+                    return [
+                        {"code": "error", "message": "Couldn't execute the query due to the read only access to Neo4j"}]
                 else:
                     return [{"code": "error", "message": e}]
 


### PR DESCRIPTION
Having a way to load example datasets is super helpful for people exploring, learning, and demoing.  As such I re-implemented the kg_chat `load` endpoint that was taken out in #29 and updated neo4j connection setup as a fix to accommodate writes for the endpoint.  Mixed in a couple of other small changes. Detailed changes below:

- Re-implemented `init` and `load` GET endpoints for kg_chat backend. Providing starter datasets is super helpful for others demoing.
  - Separated a read and write neo4j connection to allow loading while keeping other endpoint read-only.
- Small updates to kg_chat Readme for clearer demo directions
- Updated neo4j version 5.7 -> 5.9 in docker-compose
- A few minor code formatting fixes and .gitignore addition