### PR TITLE
Api key and questions

### DIFF
--- a/api/src/main.py
+++ b/api/src/main.py
@@ -68,7 +68,6 @@ app.add_middleware(
 
 @app.post("/questionProposalsForCurrentDb")
 async def questionProposalsForCurrentDb(payload: questionProposalPayload):
-    print(type(payload))
     if not openai_api_key and not payload.api_key:
         raise HTTPException(
             status_code=422,

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -90,7 +90,7 @@ async def questionProposalsForCurrentDb(payload: questionProposalPayload):
 
 @app.get("/hasapikey")
 async def hasApiKey():
-    return JSONResponse(content={"output": openai_api_key == None})
+    return JSONResponse(content={"output": openai_api_key is not None})
 
 
 @app.websocket("/text2text")

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -68,12 +68,13 @@ app.add_middleware(
 
 @app.post("/questionProposalsForCurrentDb")
 async def questionProposalsForCurrentDb(payload: questionProposalPayload):
-    if not openai_api_key and not payload.get("api_key"):
+    print(type(payload))
+    if not openai_api_key and not payload.api_key:
         raise HTTPException(
             status_code=422,
             detail="Please set OPENAI_API_KEY environment variable or send it as api_key in the request body",
         )
-    api_key = openai_api_key if openai_api_key else payload.get("api_key")
+    api_key = openai_api_key if openai_api_key else payload.api_key
 
     questionProposalGenerator = QuestionProposalGenerator(
         database=neo4j_connection,
@@ -193,12 +194,12 @@ async def root(payload: ImportPayload):
     """
     Takes an input and created a Cypher query
     """
-    if not openai_api_key and not payload.get("api_key"):
+    if not openai_api_key and not payload.api_key:
         raise HTTPException(
             status_code=422,
             detail="Please set OPENAI_API_KEY environment variable or send it as api_key in the request body",
         )
-    api_key = openai_api_key if openai_api_key else payload.get("api_key")
+    api_key = openai_api_key if openai_api_key else payload.api_key
 
     try:
         result = ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
   frontend:
     build:
       context: ./ui
-    environment:
-      - VITE_KG_CHAT_BACKEND_ENDPOINT=ws://kg-chat-backend:7860/text2text
     hostname: ui
     restart: always
     container_name: ui

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,2 +1,4 @@
-VITE_UNSTRUCTURED_IMPORT_BACKEND_ENDPOINT=http://localhost:7860
+VITE_UNSTRUCTURED_IMPORT_BACKEND_ENDPOINT=http://localhost:7860/data2cypher
 VITE_KG_CHAT_BACKEND_ENDPOINT=ws://localhost:7860/text2text
+VITE_HAS_API_KEY_ENDPOINT=http://localhost:7860/hasapikey
+VITE_KG_CHAT_SAMPLE_QUESTIONS_ENDPOINT=http://localhost:7860/questionProposalsForCurrentDb

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,11 +11,13 @@
       "dependencies": {
         "@neo4j-ndl/base": "1.4.0",
         "@neo4j/graph-schema-utils": "^1.0.0-next.9",
+        "@types/react-modal": "^3.16.0",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
         "nanoid": "^4.0.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-modal": "^3.16.1",
         "react-use-websocket": "^4.3.1",
         "typescript": "^5.0.4"
       },
@@ -1003,14 +1005,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.7.tgz",
       "integrity": "sha512-ojrXpSH2XFCmHm7Jy3q44nXDyN54+EYKP2lBhJ2bqfyPj6cIUW/FZW/Csdia34NQgq7KYcAlHi5184m4X88+yw==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1026,11 +1026,18 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
+      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
-      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==",
-      "dev": true
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/sockjs-client": {
       "version": "1.5.1",
@@ -1542,8 +1549,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/daisyui": {
       "version": "2.51.6",
@@ -2100,6 +2106,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3104,7 +3115,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3554,7 +3564,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3615,8 +3624,30 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -4318,6 +4349,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,11 +26,13 @@
   "dependencies": {
     "@neo4j-ndl/base": "1.4.0",
     "@neo4j/graph-schema-utils": "^1.0.0-next.9",
+    "@types/react-modal": "^3.16.0",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "nanoid": "^4.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-modal": "^3.16.1",
     "react-use-websocket": "^4.3.1",
     "typescript": "^5.0.4"
   },

--- a/ui/src/chat-with-kg/App.tsx
+++ b/ui/src/chat-with-kg/App.tsx
@@ -3,6 +3,7 @@ import ChatContainer from "./ChatContainer";
 import type { ChatMessageObject } from "./ChatMessage";
 import ChatInput from "./ChatInput";
 import useWebSocket, { ReadyState } from "react-use-websocket";
+import KeyModal from "../components/keymodal";
 import type {
   ConversationState,
   WebSocketRequest,
@@ -36,7 +37,31 @@ const URI =
   import.meta.env.VITE_KG_CHAT_BACKEND_ENDPOINT ??
   "ws://localhost:7860/text2text";
 
+const HAS_API_KEY_URI =
+  import.meta.env.VITE_HAS_API_KEY_ENDPOINT ??
+  "http://localhost:7860/hasapikey";
+
+const QUESTIONS_URI =
+  import.meta.env.VITE_KG_CHAT_SAMPLE_QUESTIONS_ENDPOINT ??
+  "http://localhost:7860/questionProposalsForCurrentDb";
+
+function loadKeyFromStorage() {
+  return localStorage.getItem("api_key");
+}
+
+const QUESTION_PREFIX_REGEXP = /^[0-9]{1,2}[\w]*[\.\)\-]*[\w]*/;
+
+function stripQuestionPrefix(question: string): string {
+  if (question.match(QUESTION_PREFIX_REGEXP)) {
+    return question.replace(QUESTION_PREFIX_REGEXP, "");
+  }
+  return question;
+}
+
 function App() {
+  const [serverAvailable, setServerAvailable] = useState(true);
+  const [needsApiKeyLoading, setNeedsApiKeyLoading] = useState(true);
+  const [needsApiKey, setNeedsApiKey] = useState(true);
   const [chatMessages, setChatMessages] = useState(chatMessageObjects);
   const [conversationState, setConversationState] =
     useState<ConversationState>("ready");
@@ -45,9 +70,71 @@ function App() {
     reconnectInterval: 5000,
   });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [apiKey, setApiKey] = useState(loadKeyFromStorage() || "");
+  const [sampleQuestions, setSampleQuestions] = useState<string[]>([]);
+
+  const showContent = serverAvailable && !needsApiKeyLoading;
+
+  function loadSampleQuestions() {
+    const body = {};
+    const options = {
+      method: "POST" ,
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    };
+    fetch(QUESTIONS_URI, options).then(
+      response => {
+        response.json().then(
+          result => {
+            if (result.output && result.output.length > 0) {
+              setSampleQuestions(result.output.map(stripQuestionPrefix));
+            } else {
+              setSampleQuestions([]);
+            }
+          },
+          error => {
+            setSampleQuestions([]);
+          }
+        );
+      },
+      error => {
+        setSampleQuestions([]);
+    });
+  };
 
   useEffect(() => {
-    if (!lastMessage) {
+    fetch(HAS_API_KEY_URI).then(response => {
+      response.json().then(result => {
+        // const needsKey = result.output;
+        const needsKey = !result.output;
+        setNeedsApiKey(needsKey);
+        setNeedsApiKeyLoading(false);
+        if (needsKey) {
+          const api_key = loadKeyFromStorage();
+          if (api_key) {
+            setApiKey(api_key);
+            loadSampleQuestions();
+          } else {
+            setModalIsOpen(true);
+          }
+        } else {
+          loadSampleQuestions();
+        }
+      }, error => {
+        setNeedsApiKeyLoading(false);
+        setServerAvailable(false);
+      });
+    }, error => {
+      setNeedsApiKeyLoading(false);
+      setServerAvailable(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!lastMessage || !serverAvailable) {
       return;
     }
 
@@ -94,6 +181,7 @@ function App() {
           {
             ...lastChatMessage,
             complete: true,
+            cypher: websocketResponse.generated_cypher
           },
         ];
       });
@@ -115,6 +203,9 @@ function App() {
       type: "question",
       question: question,
     };
+    if (serverAvailable && !needsApiKeyLoading && needsApiKey && apiKey) {
+      webSocketRequest.api_key = apiKey;
+    }
     sendJsonMessage(webSocketRequest);
   };
 
@@ -139,10 +230,35 @@ function App() {
     }
   };
 
+  const openModal = () => {
+    setModalIsOpen(true);
+  };
+
+  const onCloseModal = () => {
+    setModalIsOpen(false);
+    if (apiKey && sampleQuestions.length === 0) {
+      loadSampleQuestions();
+    }
+  };
+
+  const onApiKeyChange = (newApiKey: string) => {
+    setApiKey(newApiKey);
+    localStorage.setItem("api_key", newApiKey);
+  }
+
   return (
     <div className="flex flex-col min-w-[800px] min-h-[100vh] bg-palette-neutral-bg-strong">
+      {needsApiKey && <div className="flex justify-end mr-4"><button onClick={openModal}>API Key</button></div>}
       <div className="p-6 mx-auto mt-20 rounded-lg bg-palette-neutral-bg-weak min-h-[6rem] min-w-[18rem] max-w-4xl ">
-        {readyState === ReadyState.OPEN && (
+        {!serverAvailable && <div>Server is unavailable, please reload the page to try again.</div>}
+        {serverAvailable && needsApiKeyLoading && <div>Initializing...</div>}
+        <KeyModal
+          isOpen={showContent && needsApiKey && modalIsOpen}
+          onCloseModal={onCloseModal}
+          onApiKeyChanged={onApiKeyChange}
+          apiKey={apiKey}
+        />
+        {showContent && readyState === ReadyState.OPEN && (
           <>
             <ChatContainer
               chatMessages={chatMessages}
@@ -151,12 +267,13 @@ function App() {
             <ChatInput
               onChatInput={onChatInput}
               loading={conversationState === "waiting"}
+              sampleQuestions={sampleQuestions}
             />
             {errorMessage}
           </>
         )}{" "}
-        {readyState === ReadyState.CONNECTING && <div>Connecting...</div>}
-        {readyState === ReadyState.CLOSED && (
+        {showContent && readyState === ReadyState.CONNECTING && <div>Connecting...</div>}
+        {showContent && readyState === ReadyState.CLOSED && (
           <div className="flex flex-col">
             <div>Could not connect to server, reconnecting...</div>
           </div>

--- a/ui/src/chat-with-kg/App.tsx
+++ b/ui/src/chat-with-kg/App.tsx
@@ -77,60 +77,69 @@ function App() {
   const showContent = serverAvailable && !needsApiKeyLoading;
 
   function loadSampleQuestions() {
-    const body = {};
+    const body = {
+      api_key: apiKey,
+    };
     const options = {
-      method: "POST" ,
+      method: "POST",
       headers: {
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
     };
     fetch(QUESTIONS_URI, options).then(
-      response => {
+      (response) => {
         response.json().then(
-          result => {
+          (result) => {
             if (result.output && result.output.length > 0) {
               setSampleQuestions(result.output.map(stripQuestionPrefix));
             } else {
               setSampleQuestions([]);
             }
           },
-          error => {
+          (error) => {
             setSampleQuestions([]);
           }
         );
       },
-      error => {
+      (error) => {
         setSampleQuestions([]);
-    });
-  };
+      }
+    );
+  }
 
   useEffect(() => {
-    fetch(HAS_API_KEY_URI).then(response => {
-      response.json().then(result => {
-        // const needsKey = result.output;
-        const needsKey = !result.output;
-        setNeedsApiKey(needsKey);
-        setNeedsApiKeyLoading(false);
-        if (needsKey) {
-          const api_key = loadKeyFromStorage();
-          if (api_key) {
-            setApiKey(api_key);
-            loadSampleQuestions();
-          } else {
-            setModalIsOpen(true);
+    fetch(HAS_API_KEY_URI).then(
+      (response) => {
+        response.json().then(
+          (result) => {
+            // const needsKey = result.output;
+            const needsKey = !result.output;
+            setNeedsApiKey(needsKey);
+            setNeedsApiKeyLoading(false);
+            if (needsKey) {
+              const api_key = loadKeyFromStorage();
+              if (api_key) {
+                setApiKey(api_key);
+                loadSampleQuestions();
+              } else {
+                setModalIsOpen(true);
+              }
+            } else {
+              loadSampleQuestions();
+            }
+          },
+          (error) => {
+            setNeedsApiKeyLoading(false);
+            setServerAvailable(false);
           }
-        } else {
-          loadSampleQuestions();
-        }
-      }, error => {
+        );
+      },
+      (error) => {
         setNeedsApiKeyLoading(false);
         setServerAvailable(false);
-      });
-    }, error => {
-      setNeedsApiKeyLoading(false);
-      setServerAvailable(false);
-    });
+      }
+    );
   }, []);
 
   useEffect(() => {
@@ -181,7 +190,7 @@ function App() {
           {
             ...lastChatMessage,
             complete: true,
-            cypher: websocketResponse.generated_cypher
+            cypher: websocketResponse.generated_cypher,
           },
         ];
       });
@@ -244,13 +253,19 @@ function App() {
   const onApiKeyChange = (newApiKey: string) => {
     setApiKey(newApiKey);
     localStorage.setItem("api_key", newApiKey);
-  }
+  };
 
   return (
     <div className="flex flex-col min-w-[800px] min-h-[100vh] bg-palette-neutral-bg-strong">
-      {needsApiKey && <div className="flex justify-end mr-4"><button onClick={openModal}>API Key</button></div>}
+      {needsApiKey && (
+        <div className="flex justify-end mr-4">
+          <button onClick={openModal}>API Key</button>
+        </div>
+      )}
       <div className="p-6 mx-auto mt-20 rounded-lg bg-palette-neutral-bg-weak min-h-[6rem] min-w-[18rem] max-w-4xl ">
-        {!serverAvailable && <div>Server is unavailable, please reload the page to try again.</div>}
+        {!serverAvailable && (
+          <div>Server is unavailable, please reload the page to try again.</div>
+        )}
         {serverAvailable && needsApiKeyLoading && <div>Initializing...</div>}
         <KeyModal
           isOpen={showContent && needsApiKey && modalIsOpen}
@@ -272,7 +287,9 @@ function App() {
             {errorMessage}
           </>
         )}{" "}
-        {showContent && readyState === ReadyState.CONNECTING && <div>Connecting...</div>}
+        {showContent && readyState === ReadyState.CONNECTING && (
+          <div>Connecting...</div>
+        )}
         {showContent && readyState === ReadyState.CLOSED && (
           <div className="flex flex-col">
             <div>Could not connect to server, reconnecting...</div>

--- a/ui/src/chat-with-kg/ChatInput.tsx
+++ b/ui/src/chat-with-kg/ChatInput.tsx
@@ -1,7 +1,8 @@
-import { useState, KeyboardEvent } from "react";
+import { useState, useEffect, KeyboardEvent } from "react";
 export type ChatInputProps = {
   onChatInput?: (chatText: string) => void;
   loading?: boolean;
+  sampleQuestions: string[]
 };
 
 //Needed since the types for react don't include enterKeyHint
@@ -19,8 +20,14 @@ declare module "react" {
 }
 
 function ChatInput(props: ChatInputProps) {
-  const { onChatInput, loading } = props;
+  const { onChatInput, loading, sampleQuestions } = props;
   const [inputText, setInputText] = useState("");
+
+  const [sampleQuestionIndex, setSampleQuestionIndex] = useState(0);
+
+  useEffect(() => {
+    setSampleQuestionIndex(0);
+  }, [sampleQuestions])
 
   const onInputKeyPress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (!loading && event.key === "Enter") {
@@ -35,41 +42,96 @@ function ChatInput(props: ChatInputProps) {
     }
   };
 
+  const sampleQuestionLeft = () => {
+    if (sampleQuestionIndex > 0) {
+      setSampleQuestionIndex(sampleQuestionIndex - 1);
+    }
+  };
+
+  const sampleQuestionRight = () => {
+    if (sampleQuestionIndex < sampleQuestions.length - 1) {
+      setSampleQuestionIndex(sampleQuestionIndex + 1);
+    }
+  };
+
+  const onSampleQuestionClick = () => {
+    const sampleQuestion = sampleQuestions[sampleQuestionIndex];
+    if (onChatInput && sampleQuestion !== undefined) {
+      onChatInput(sampleQuestion);
+    }
+  };
+
   return (
-    <div className="flex flex-row max-w-4xl gap-2">
-      {/* @ts-ignore */}
-      <textarea
-        enterKeyHint="send"
-        onChange={(e) => setInputText(e.target.value)}
-        onKeyDown={onInputKeyPress}
-        disabled={loading}
-        value={inputText}
-        rows={1}
-        className="w-full max-w-full p-3 m-0 overflow-x-hidden overflow-y-auto bg-transparent border rounded-md outline-none resize-none scroll-p-3 focus:ring-0 focus-visible:ring-0 border-palette-neutral-bg-strong"
-        placeholder="Ask something about your database"
-      ></textarea>
-      <button
-        className="flex self-center ndl-icon-btn ndl-large"
-        onClick={handleSend}
-      >
-        <div className="ndl-icon">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            aria-hidden="true"
-            className="w-6 h-6 text-light-neutral-text-weak"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
-            ></path>
-          </svg>
-        </div>
-      </button>
+    <div className="flex flex-col max-w-4xl gap-2">
+      <div className="flex flex-row w-full">
+        {/* @ts-ignore */}
+        <textarea
+          enterKeyHint="send"
+          onChange={(e) => setInputText(e.target.value)}
+          onKeyDown={onInputKeyPress}
+          disabled={loading}
+          value={inputText}
+          rows={1}
+          className="w-full max-w-full p-3 m-0 overflow-x-hidden overflow-y-auto bg-transparent border rounded-md outline-none resize-none scroll-p-3 focus:ring-0 focus-visible:ring-0 border-palette-neutral-bg-strong"
+          placeholder="Ask something about your database"
+        ></textarea>
+        <button
+          className="flex self-center ndl-icon-btn ndl-large"
+          onClick={handleSend}
+        >
+          <div className="ndl-icon">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+              className="w-6 h-6 text-light-neutral-text-weak"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5"
+              ></path>
+            </svg>
+          </div>
+        </button>
+      </div>
+      {sampleQuestions && sampleQuestions.length > 0 && (
+        <>
+          <div className="flex justify-center">Sample Questions</div>
+          <div className="flex flex-row w-full">
+            <div className="flex flex-none">
+              <button
+                className="flex self-center ndl-icon-btn ndl-large"
+                onClick={sampleQuestionLeft}
+                disabled={sampleQuestionIndex <= 0}
+              >
+                <div className="ndl-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="15 18 9 12 15 6"/>
+                </svg>
+                </div>
+              </button>
+            </div>
+            <div className="flex flex-auto m-2 cursor-pointer" onClick={onSampleQuestionClick}>{sampleQuestions[sampleQuestionIndex]}</div>
+            <div className="flex flex-none">
+              <button
+                className="flex self-center ndl-icon-btn ndl-large"
+                onClick={sampleQuestionRight}
+                disabled={sampleQuestionIndex >= sampleQuestions.length - 1}
+              >
+                <div className="ndl-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="9 18 15 12 9 6"/>
+                </svg>
+                </div>
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/ui/src/chat-with-kg/ChatMessage.tsx
+++ b/ui/src/chat-with-kg/ChatMessage.tsx
@@ -2,6 +2,7 @@ export type ChatMessageObject = {
   id: number;
   type: "input" | "text" | "error";
   message: string;
+  cypher?: string | null;
   sender: "bot" | "self";
   complete: boolean;
 };
@@ -12,7 +13,7 @@ export type ChatMessageProps = {
 
 function ChatMessage(props: ChatMessageProps) {
   const { chatMessage } = props;
-  const { type, message, sender } = chatMessage;
+  const { type, message, sender, cypher } = chatMessage;
   const chatClass = `flex flex-row relative max-w-full ${
     sender === "bot" ? "self-start mr-10" : "ml-10 self-end"
   }`;
@@ -26,6 +27,7 @@ function ChatMessage(props: ChatMessageProps) {
         }`}
       >
         {message}
+        {sender === "bot" && cypher && <ChatCypherDetail cypher={cypher} />}
       </div>
       {sender === "self" && <ChatMessageTail side="right" />}
     </div>
@@ -56,6 +58,17 @@ function ChatMessageTail({ side }: { side: "left" | "right" }) {
       className="absolute bottom-0 bg-palette-primary-bg-strong"
       style={chatTailStyle}
     ></div>
+  );
+}
+
+function ChatCypherDetail({ cypher }: { cypher: string }) {
+  return (
+    <details>
+      <summary className="">Cypher</summary>
+      <div className="min-w-0 px-4 py-2 rounded-lg bg-palette-primary-bg-weak text-palette-neutral-text-default">
+        {cypher}
+      </div>
+    </details>
   );
 }
 

--- a/ui/src/chat-with-kg/main.tsx
+++ b/ui/src/chat-with-kg/main.tsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.js";
+import Modal from "react-modal";
 
 import "@neo4j-ndl/base/lib/neo4j-ds-styles.css";
 import "./index.css";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
+
+if (container) {
+  Modal.setAppElement(container);
+}
 
 root.render(
   <React.StrictMode>

--- a/ui/src/chat-with-kg/types/websocketTypes.ts
+++ b/ui/src/chat-with-kg/types/websocketTypes.ts
@@ -1,6 +1,7 @@
 export type WebSocketRequest = {
   type: "question";
   question: string;
+  api_key?: string;
 };
 
 export type WebSocketResponse =

--- a/ui/src/components/keymodal.tsx
+++ b/ui/src/components/keymodal.tsx
@@ -1,0 +1,51 @@
+import Modal from "react-modal";
+
+type KeyModalProps = {
+  isOpen: boolean;
+  apiKey: string;
+  onRequestClose?: () => void;
+  onCloseModal: () => void;
+  onApiKeyChanged: (key: string) => void;
+};
+
+const customModalStyles = {
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+  },
+};
+const inputClassNames = "";
+
+
+function KeyModal(props: KeyModalProps) {
+  const { isOpen, apiKey, onRequestClose, onCloseModal, onApiKeyChanged } = props;
+  return (
+    <Modal
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      style={customModalStyles}
+      contentLabel="Enter Open API Key"
+    >
+      <div className="flex justify-end">
+        <button onClick={onCloseModal}>close</button>
+      </div>
+      <div className="flex">
+        <h2>Please Enter Your OpenAI API Key</h2>
+        
+      </div>
+      <form>
+        <div className="ndl-form-item">
+          {/*
+          // @ts-ignore */}
+          <input type="text" onChange={(e: Event) => { onApiKeyChanged(e.target.value); }} className={inputClassNames} value={apiKey} />
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default KeyModal;

--- a/ui/src/unstructured-import/App.tsx
+++ b/ui/src/unstructured-import/App.tsx
@@ -1,21 +1,78 @@
 import "@neo4j-ndl/base/lib/neo4j-ds-styles.css";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { runImport } from "./utils/fetch-utils";
 import { Switch } from "../components/switch";
 import { graphSchemaToModelSchema } from "./utils/graph-schema-utils";
+import KeyModal from "../components/keymodal";
 import { ImportResult } from "./types/respons-types";
 import {
   saveCypherResult,
   saveImportResultAsNeo4jImport,
 } from "./utils/file-utils";
 
+const HAS_API_KEY_URI =
+  import.meta.env.VITE_HAS_API_KEY_ENDPOINT ??
+  "http://localhost:7860/hasapikey";
+
+function loadKeyFromStorage() {
+  return localStorage.getItem("api_key");
+}
+
 function App() {
+  const [serverAvailable, setServerAvailable] = useState(true);
+  const [needsApiKeyLoading, setNeedsApiKeyLoading] = useState(true);
+  const [needsApiKey, setNeedsApiKey] = useState(true);
   const [useSchema, setUseSchema] = useState(false);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<ImportResult | null>(null);
   const [schema, setSchema] = useState<string>("");
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const [apiKey, setApiKey] = useState(loadKeyFromStorage() || "");
+
+  const initDone = serverAvailable && !needsApiKeyLoading;
+
+  useEffect(() => {
+    fetch(HAS_API_KEY_URI).then(response => {
+      response.json().then(result => {
+        // const needsKey = result.output;
+        const needsKey = !result.output;
+        setNeedsApiKey(needsKey);
+        setNeedsApiKeyLoading(false);
+        if (needsKey) {
+          const api_key = loadKeyFromStorage();
+          if (api_key) {
+            setApiKey(api_key);
+          } else {
+            setModalIsOpen(true);
+          }
+        }
+      }, error => {
+        setNeedsApiKeyLoading(false);
+        setServerAvailable(false);
+      });
+    }, error => {
+      setNeedsApiKeyLoading(false);
+      setServerAvailable(false);
+    });
+  }, []);
+
+  const openModal = () => {
+    setModalIsOpen(true);
+  };
+
+  const onCloseModal = () => {
+    setModalIsOpen(false);
+  };
+
+  const onApiKeyChange = (newApiKey: string) => {
+    setApiKey(newApiKey);
+    localStorage.setItem("api_key", newApiKey);
+  }
 
   const handleImport = async () => {
+    if (!serverAvailable || needsApiKeyLoading) {
+      return;
+    }
     setLoading(true);
     setResult(null);
     const file = document.querySelector(".file-input") as HTMLInputElement;
@@ -31,7 +88,8 @@ function App() {
         console.log("schema json", schemaJson);
         const importResult = await runImport(
           reader.result as string,
-          schemaJson
+          schemaJson,
+          needsApiKey ? apiKey : undefined
         );
         console.log("import result", importResult);
         if (importResult) {
@@ -47,74 +105,94 @@ function App() {
     const text = reader.readAsText(file.files![0]);
   };
 
-  return (
-    <div className="min-h-screen n-bg-palette-neutral-bg-default">
-      <main className="flex flex-col gap-10 p-2">
-        <div className="flex flex-col w-2/3 min-h-0 gap-2 mx-auto mt-10">
-          <h1 className="text-4xl font-bold text-center">Import data</h1>
-          <p>
-            This tool is used to import unstructured data into Neo4j. It takes a
-            file as input and optionally a schema in the form of{" "}
-            <a href="https://neo4j.com/developer-blog/describing-property-graph-data-model/">
-              graph data model
-            </a>{" "}
-            which is used to limit the data that is extracted from the file.
-            It's important to give the schema descriptive tokens so the tool can
-            identify the data that is imported.
-          </p>
-
-          <Switch
-            label="Use schema"
-            checked={useSchema}
-            onChange={() => setUseSchema(!useSchema)}
-          />
-          {useSchema ? (
-            <div className="flex flex-col gap-4">
-              Please provide your schema in json format:
-              <textarea
-                className="px-3 border rounded-sm body-medium border-palette-neutral-border-strong bg-palette-neutral-bg-weak"
-                value={schema}
-                onChange={(e) => setSchema(e.target.value)}
-              />
-            </div>
-          ) : null}
-
-          <input type="file" className={`w-full max-w-xs file-input`} />
-          <button
-            className={`ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong ${
-              loading ? "ndl-loading" : ""
-            }`}
-            onClick={handleImport}
-          >
-            {loading ? "Importing. This will take a while..." : "Import"}
-          </button>
-        </div>
-
-        <div>
-          {result ? (
-            <div className="flex flex-col w-2/3 gap-2 mx-auto">
-              <h1 className="text-4xl font-bold text-center">Result</h1>
-              <p>
-                The import was successful. You can save the result as a cypher.
-              </p>
-              <button
-                className="ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong"
-                onClick={() => saveCypherResult(result)}
-              >
-                Save as Cypher
-              </button>
-              <button
-                className="ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong"
-                onClick={() => saveImportResultAsNeo4jImport(result)}
-              >
-                Save as Neo4j Import format
-              </button>
-            </div>
-          ) : null}
-        </div>
-      </main>
-    </div>
-  );
+  if (serverAvailable) {
+    return (
+      <div className="min-h-screen n-bg-palette-neutral-bg-default">
+        {needsApiKey && <div className="flex justify-end mr-4"><button onClick={openModal}>API Key</button></div>}
+        <KeyModal
+          isOpen={initDone && needsApiKey && modalIsOpen}
+          onCloseModal={onCloseModal}
+          onApiKeyChanged={onApiKeyChange}
+          apiKey={apiKey}
+        />
+        <main className="flex flex-col gap-10 p-2">
+          <div className="flex flex-col w-2/3 min-h-0 gap-2 mx-auto mt-10">
+            <h1 className="text-4xl font-bold text-center">Import data</h1>
+            <p>
+              This tool is used to import unstructured data into Neo4j. It takes a
+              file as input and optionally a schema in the form of{" "}
+              <a href="https://neo4j.com/developer-blog/describing-property-graph-data-model/">
+                graph data model
+              </a>{" "}
+              which is used to limit the data that is extracted from the file.
+              It's important to give the schema descriptive tokens so the tool can
+              identify the data that is imported.
+            </p>
+  
+            <Switch
+              label="Use schema"
+              checked={useSchema}
+              onChange={() => setUseSchema(!useSchema)}
+            />
+            {useSchema ? (
+              <div className="flex flex-col gap-4">
+                Please provide your schema in json format:
+                <textarea
+                  className="px-3 border rounded-sm body-medium border-palette-neutral-border-strong bg-palette-neutral-bg-weak"
+                  value={schema}
+                  onChange={(e) => setSchema(e.target.value)}
+                />
+              </div>
+            ) : null}
+  
+            <input type="file" className={`w-full max-w-xs file-input`} />
+            <button
+              className={`ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong ${
+                loading ? "ndl-loading" : ""
+              }`}
+              onClick={handleImport}
+              disabled={!initDone}
+            >
+              {loading ? "Importing. This will take a while..." : "Import"}
+            </button>
+          </div>
+  
+          <div>
+            {result ? (
+              <div className="flex flex-col w-2/3 gap-2 mx-auto">
+                <h1 className="text-4xl font-bold text-center">Result</h1>
+                <p>
+                  The import was successful. You can save the result as a cypher.
+                </p>
+                <button
+                  className="ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong"
+                  onClick={() => saveCypherResult(result)}
+                >
+                  Save as Cypher
+                </button>
+                <button
+                  className="ndl-btn ndl-large ndl-filled ndl-primary n-bg-palette-primary-bg-strong"
+                  onClick={() => saveImportResultAsNeo4jImport(result)}
+                >
+                  Save as Neo4j Import format
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </main>
+      </div>
+    );
+  } else {
+    return (
+      <div className="min-h-screen n-bg-palette-neutral-bg-default">
+        <main className="flex flex-col gap-10 p-2">
+          <div className="flex flex-col w-2/3 min-h-0 gap-2 mx-auto mt-10">
+            <p></p>
+          </div>
+        </main>
+      </div>
+    );
+  }
 }
 
 export default App;

--- a/ui/src/unstructured-import/main.tsx
+++ b/ui/src/unstructured-import/main.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.js";
+import Modal from "react-modal";
 import "./index.css";
 
 const container = document.getElementById("root");
 const root = createRoot(container!);
+
+if (container) {
+  Modal.setAppElement(container);
+}
 
 root.render(
   <React.StrictMode>

--- a/ui/src/unstructured-import/utils/fetch-utils.ts
+++ b/ui/src/unstructured-import/utils/fetch-utils.ts
@@ -5,8 +5,15 @@ type JSONResponse = {
   errors?: Array<{ message: string }>;
 };
 
-export const runImport = async (input: string, schema?: string) => {
+export const runImport = async (input: string, schema?: string, apiKey?: string) => {
   console.log("sending body", JSON.stringify({ input, neo4j_schema: schema }));
+  const body = {
+    input, neo4j_schema: schema ? schema : ""
+  };
+  if (apiKey) {
+    // @ts-ignore
+    body.api_key = apiKey;
+  }
   const response = await fetch(
     `${import.meta.env.VITE_UNSTRUCTURED_IMPORT_BACKEND_ENDPOINT}/data2cypher`,
     {
@@ -14,7 +21,7 @@ export const runImport = async (input: string, schema?: string) => {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ input, neo4j_schema: schema ? schema : "" }),
+      body: JSON.stringify(body),
     }
   );
   if (!response.ok) {


### PR DESCRIPTION
This PR adds a few things:

1 - sample questions appear below the chat prompt with left/right buttons to navigate since they were too long to show all at once (could use some style improvement)
2 - Adds a check to see if the server has an open ai api key on startup, and if not prompts the user to provide one in a modal (also could use some style improvement). In case the server doesn't have an api key and the user provides one, it is passed on all calls to the server from both demo apps/use-cases.
3 - The chat bubbles for responses from the server now show a drop down allowing the user to examine the generated cypher query when present (could also use some style improvement)

Note there seems to be a strange cors related error on the sample questions endpoint that only happens when the server is not configured with an api key.